### PR TITLE
marshmallow-oneofschema 3.2.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,13 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Marshmallow library extension that allows schema (de)multiplexing
-
+  description: |
+    This library adds a special kind of schema that actually multiplexes other schemas based on object type. 
+    When serializing values, it uses get_obj_type() method to get object type name. Then it uses type_schemas 
+    name-to-Schema mapping to get schema for that particular object type, serializes object using that schema and
+    adds an extra field with name of object type. Deserialization is reverse.
+  dev_url: https://github.com/marshmallow-code/marshmallow-oneofschema
+  doc_url: https://marshmallow.readthedocs.io
 extra:
   recipe-maintainers:
     - dhirschfeld

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,39 @@
 {% set name = "marshmallow-oneofschema" %}
-{% set version = "3.0.1" %}
+{% set version = "3.2.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name | lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 62cd2099b29188c92493c2940ee79d1bf2f2619a71721664e5a98ec2faa58237
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/marshmallow_oneofschema-{{ version }}.tar.gz
+  sha256: c06c8d9f14d51ffff152d66d85bd5f27d55cff10752a3b1f8c1f948bf5f597a0
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True  # [py<39]
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
-
+    - flit-core
   run:
     - python
-    - marshmallow >=3.0.0,<4.0.0
+    - marshmallow >=3.0.0,<5.0.0
 
 test:
+  source_files:
+    - tests
   imports:
     - marshmallow_oneofschema
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest -vv tests
 
 about:
   home: https://github.com/marshmallow-code/marshmallow-oneofschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/marshmallow_oneofschema-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: c06c8d9f14d51ffff152d66d85bd5f27d55cff10752a3b1f8c1f948bf5f597a0
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - flit-core
+    - flit-core <4
   run:
     - python
     - marshmallow >=3.0.0,<5.0.0


### PR DESCRIPTION
marshmallow-oneofschema 3.2.0 

**Destination channel:** Defaults

### Links

- [PKG-8176]
- dev_url:        https://github.com/marshmallow-code/marshmallow-oneofschema/tree/3.2.0
- conda_forge:    https://github.com/conda-forge/marshmallow-oneofschema-feedstock
- pypi:           https://pypi.org/project/marshmallow-oneofschema/3.2.0
- pypi inspector: https://inspector.pypi.io/project/marshmallow-oneofschema/3.2.0

### Explanation of changes:

- new version number
- adding tests


[PKG-8176]: https://anaconda.atlassian.net/browse/PKG-8176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ